### PR TITLE
feat: add CoursePlanSelector component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,9 @@ import SchoolReportList from "./pages/SchoolReportList";
 
 import Loading from "./components/Loading";
 
+// Styles
+import "@orif-informatique/react-components-library/styles.css";
+
 
 /**
  * Defines routes and is the app base.

--- a/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.css
+++ b/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.css
@@ -1,0 +1,52 @@
+/* ── Root container ─────────────────────────────────────────── */
+.course-plan-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Override library label gap ─────────────────────────────── */
+.course-plan-selector label {
+  gap: 8px;
+}
+
+/* ── Info row: three blocks side by side ────────────────────── */
+.course-plan-selector__info {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+/* ── Individual info block: label stacked above value ───────── */
+.course-plan-selector__info-block {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ── Label text ─────────────────────────────────────────────── */
+.course-plan-selector__info-block-label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+/* ── Value text ─────────────────────────────────────────────── */
+.course-plan-selector__info-block-value {
+  font-size: 0.95rem;
+}
+
+/* ── Small screens (≤ 600 px) ──────────────────────────────── */
+@media (max-width: 600px) {
+  /* Stack the three blocks vertically */
+  .course-plan-selector__info {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  /* Each block displays label and value on the same line */
+  .course-plan-selector__info-block {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}

--- a/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
+++ b/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
@@ -1,3 +1,49 @@
 import React from "react";
-import { InputSingleSelect, Label } from "@orif-informatique/react-components-library";
+import { SingleSelect } from "@orif-informatique/react-components-library";
+import PropTypes from "prop-types";
 
+export default function CoursePlanSelector({
+  coursePlans = [],
+  selectedCoursePlan = null,
+  onCoursePlanChange,
+}) {
+  return (
+    <div className="course-plan-selector">
+      <SingleSelect
+        name="course-plan"
+        label="Formation(s) suivie(s)"
+        options={coursePlans}
+        selectedValue={selectedCoursePlan?.id}
+        onChangeFunction={onCoursePlanChange}
+      />
+      <div className="course-plan-selector__info">
+        <span>Date début</span>
+        <span>{selectedCoursePlan?.startDate}</span>
+        <span>Date fin</span>
+        <span>{selectedCoursePlan?.endDate}</span>
+        <span>Status de la formation</span>
+        <span>{selectedCoursePlan?.status}</span>
+      </div>
+    </div>
+  );
+}
+
+CoursePlanSelector.propTypes = {
+  coursePlans: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      startDate: PropTypes.string,
+      endDate: PropTypes.string,
+      status: PropTypes.string,
+    }),
+  ),
+  selectedCoursePlan: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    startDate: PropTypes.string,
+    endDate: PropTypes.string,
+    status: PropTypes.string,
+  }),
+  onCoursePlanChange: PropTypes.func,
+};

--- a/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
+++ b/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
@@ -12,7 +12,7 @@ export default function CoursePlanSelector({
       <SingleSelect
         name="course-plan"
         label="Formation(s) suivie(s)"
-        options={coursePlans}
+        options={coursePlans.map((cp) => ({ value: cp.id, label: cp.label }))}
         selectedValue={selectedCoursePlan?.id}
         onChangeFunction={onCoursePlanChange}
       />

--- a/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
+++ b/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SingleSelect } from "@orif-informatique/react-components-library";
 import PropTypes from "prop-types";
+import "./CoursePlanSelector.css";
 
 export default function CoursePlanSelector({
   coursePlans = [],
@@ -17,12 +18,30 @@ export default function CoursePlanSelector({
         onChangeFunction={onCoursePlanChange}
       />
       <div className="course-plan-selector__info">
-        <span>Date début</span>
-        <span>{selectedCoursePlan?.startDate}</span>
-        <span>Date fin</span>
-        <span>{selectedCoursePlan?.endDate}</span>
-        <span>Status de la formation</span>
-        <span>{selectedCoursePlan?.status}</span>
+        <div className="course-plan-selector__info-block">
+          <span className="course-plan-selector__info-block-label">
+            Date début :
+          </span>
+          <span className="course-plan-selector__info-block-value">
+            {selectedCoursePlan?.startDate}
+          </span>
+        </div>
+        <div className="course-plan-selector__info-block">
+          <span className="course-plan-selector__info-block-label">
+            Date fin :
+          </span>
+          <span className="course-plan-selector__info-block-value">
+            {selectedCoursePlan?.endDate}
+          </span>
+        </div>
+        <div className="course-plan-selector__info-block">
+          <span className="course-plan-selector__info-block-label">
+            Status de la formation :
+          </span>
+          <span className="course-plan-selector__info-block-value">
+            {selectedCoursePlan?.status}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
+++ b/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.jsx
@@ -1,0 +1,3 @@
+import React from "react";
+import { InputSingleSelect, Label } from "@orif-informatique/react-components-library";
+

--- a/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.stories.jsx
+++ b/frontend/src/features/progress-report/components/course-plan-selector/CoursePlanSelector.stories.jsx
@@ -1,0 +1,105 @@
+import CoursePlanSelector from "./CoursePlanSelector";
+
+const meta = {
+  component: CoursePlanSelector,
+  tags: ["autodocs"],
+  args: {
+    coursePlans: [
+      {
+        id: "1",
+        label:
+          "Informaticienne / informaticien avec CFC, orientation développement d’applications",
+        startDate: "01.08.2025",
+        endDate: "31.07.2029",
+        status: "En cours",
+      },
+      {
+        id: "2",
+        label:
+          "[2014-2020] Informaticienne, informaticien avec CFC, orientation développement d’applications",
+        startDate: "01.08.2020",
+        endDate: "31.07.2022",
+        status: "Abandonnée",
+      },
+    ],
+
+    selectedCoursePlan: {
+      id: "1",
+      label:
+        "Informaticienne / informaticien avec CFC, orientation développement d'applications",
+      startDate: "01.08.2025",
+      endDate: "31.07.2029",
+      status: "En cours",
+    },
+  },
+};
+
+export default meta;
+
+// Default: Multiple courses available, one is selected
+export const Default = {};
+
+// No course plan selected yet — info section is empty
+export const NoSelection = {
+  args: {
+    selectedCoursePlan: null,
+  },
+};
+
+// Only one course plan available — selector is disabled, formation is pre-selected
+export const SingleCoursePlan = {
+  args: {
+    coursePlans: [
+      {
+        id: "1",
+        label:
+          "Informaticienne / informaticien avec CFC, orientation développement d’applications",
+        startDate: "01.08.2025",
+        endDate: "31.07.2029",
+        status: "En cours",
+      },
+    ],
+
+    selectedCoursePlan: {
+      id: "1",
+      label:
+        "Informaticienne / informaticien avec CFC, orientation développement d’applications",
+      startDate: "01.08.2025",
+      endDate: "31.07.2029",
+      status: "En cours",
+    },
+  },
+};
+
+// Formation name exceeds typical length — tests label truncation in the dropdown
+export const LongLabel = {
+  args: {
+    coursePlans: [
+      {
+        id: "1",
+        label:
+          "Informaticienne / informaticien avec CFC, orientation développement d’applications et des systèmes d’information complexes en environnement professionnel et multi-plateformes",
+        startDate: "01.08.2025",
+        endDate: "31.07.2029",
+        status: "En cours",
+      },
+      {
+        id: "2",
+        label:
+          "[2014-2020] Informaticienne, informaticien avec CFC, orientation développement d’applications",
+        startDate: "01.08.2020",
+        endDate: "31.07.2022",
+        status: "Abandonnée",
+      },
+    ],
+
+    selectedCoursePlan: {
+      id: "1",
+      label:
+        "Informaticienne / informaticien avec CFC, orientation développement d’applications. Test for a very long Label : Pour lancer les tests de votre application React, ouvrez votre terminal à la racine du projet et exécutez la commande du script de test configuré dans votre fichier",
+      startDate: "01.08.2025",
+      endDate: "31.07.2029",
+      status: "En cours",
+    },
+  },
+};

--- a/frontend/src/features/progress-report/components/course-plan-selector/__fixtures__/bad-data.json
+++ b/frontend/src/features/progress-report/components/course-plan-selector/__fixtures__/bad-data.json
@@ -1,0 +1,17 @@
+{
+  "emptyCoursePlans": [],
+
+  "coursePlansWithMissingFields": [
+    {
+      "id": "1"
+    },
+    {
+      "label": "Formation sans id"
+    }
+  ],
+
+  "selectedCoursePlanMissingFields": {
+    "id": "1",
+    "label": "Formation incomplète"
+  }
+}

--- a/frontend/src/features/progress-report/components/course-plan-selector/__fixtures__/course-plan-data.json
+++ b/frontend/src/features/progress-report/components/course-plan-selector/__fixtures__/course-plan-data.json
@@ -1,0 +1,28 @@
+{
+  "coursePlans": [
+    {
+      "id": "1",
+      "label": "Informaticienne / informaticien avec CFC, orientation développement d’applications",
+      "startDate": "01.08.2025",
+      "endDate": "31.07.2029",
+      "status": "En cours"
+    },
+    {
+      "id": "2",
+      "label": "[2014-2020] Informaticienne, informaticien avec CFC, orientation développement d’applications",
+      "startDate": "01.08.2020",
+      "endDate": "31.07.2022",
+      "status": "Abandonnée"
+    }
+  ],
+
+  "selectedCoursePlan": null,
+
+  "selectedCoursePlanFilled": {
+    "id": "1",
+    "label": "Informaticienne / informaticien avec CFC, orientation développement d'applications",
+    "startDate": "01.08.2025",
+    "endDate": "31.07.2029",
+    "status": "En cours"
+  }
+}

--- a/frontend/src/features/progress-report/components/course-plan-selector/__tests__/CoursePlanSelector.test.jsx
+++ b/frontend/src/features/progress-report/components/course-plan-selector/__tests__/CoursePlanSelector.test.jsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CoursePlanSelector from "../CoursePlanSelector";
+import coursePlanData from "../__fixtures__/course-plan-data.json";
+import badData from "../__fixtures__/bad-data.json";
+
+// SingleSelect is replaced by a plain <select> to avoid depending on the
+// external library in unit tests. The mock exposes the same props so we
+// can verify they are wired correctly.
+jest.mock("@orif-informatique/react-components-library", () => ({
+  __esModule: true,
+  SingleSelect: ({ options, selectedValue, onChangeFunction }) => (
+    <select
+      data-testid="mock-single-select"
+      value={selectedValue ?? ""}
+      onChange={(e) => onChangeFunction(e.target.value)}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockOnChange = jest.fn();
+
+// --- Tests ---
+describe("CoursePlanSelector", () => {
+  // Reset the mock between tests to avoid call count bleeding across groups.
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // Verifies that the component renders its core structure correctly.
+  describe("Initial render", () => {
+    beforeEach(() => {
+      render(
+        <CoursePlanSelector
+          coursePlans={coursePlanData.coursePlans}
+          selectedCoursePlan={coursePlanData.selectedCoursePlan}
+          onCoursePlanChange={mockOnChange}
+        />,
+      );
+    });
+
+    it("renders the SingleSelect", () => {
+      expect(screen.getByTestId("mock-single-select")).toBeInTheDocument();
+    });
+
+    it("renders the correct number of options in the SingleSelect", () => {
+      expect(screen.getAllByRole("option")).toHaveLength(
+        coursePlanData.coursePlans.length,
+      );
+    });
+  });
+
+  // Verifies that the selected formation's details are displayed.
+  describe("Selected course plan", () => {
+    beforeEach(() => {
+      render(
+        <CoursePlanSelector
+          coursePlans={coursePlanData.coursePlans}
+          selectedCoursePlan={coursePlanData.selectedCoursePlanFilled}
+          onCoursePlanChange={mockOnChange}
+        />,
+      );
+    });
+
+    it("displays the start date", () => {
+      expect(
+        screen.getByText(coursePlanData.selectedCoursePlanFilled.startDate),
+      ).toBeInTheDocument();
+    });
+
+    it("displays the end date", () => {
+      expect(
+        screen.getByText(coursePlanData.selectedCoursePlanFilled.endDate),
+      ).toBeInTheDocument();
+    });
+
+    it("displays the status", () => {
+      expect(
+        screen.getByText(coursePlanData.selectedCoursePlanFilled.status),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // Verifies that changing the selection calls the parent callback.
+  describe("Interaction", () => {
+    beforeEach(() => {
+      render(
+        <CoursePlanSelector
+          coursePlans={coursePlanData.coursePlans}
+          selectedCoursePlan={coursePlanData.selectedCoursePlanFilled}
+          onCoursePlanChange={mockOnChange}
+        />,
+      );
+    });
+
+    it("calls onCoursePlanChange with the selected id", async () => {
+      await userEvent.selectOptions(
+        screen.getByTestId("mock-single-select"),
+        coursePlanData.coursePlans[0].id,
+      );
+      expect(mockOnChange).toHaveBeenCalledWith(
+        coursePlanData.coursePlans[0].id,
+      );
+    });
+  });
+
+  // Verifies that the component handles missing or empty props gracefully.
+  describe("Default props", () => {
+    it("renders without crashing when no props are provided", () => {
+      render(<CoursePlanSelector />);
+      expect(screen.getByTestId("mock-single-select")).toBeInTheDocument();
+    });
+
+    it("displays no formation info when selectedCoursePlan is null", () => {
+      render(
+        <CoursePlanSelector
+          coursePlans={badData.emptyCoursePlans}
+          selectedCoursePlan={null}
+          onCoursePlanChange={mockOnChange}
+        />,
+      );
+      expect(screen.queryByText(coursePlanData.selectedCoursePlanFilled.startDate)).not.toBeInTheDocument();
+      expect(screen.queryByText(coursePlanData.selectedCoursePlanFilled.endDate)).not.toBeInTheDocument();
+      expect(screen.queryByText(coursePlanData.selectedCoursePlanFilled.status)).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `CoursePlanSelector` controlled component displaying the selected formation name, start date, end date, and status
- Add unit tests with fixtures (valid and invalid data) covering initial render, selected state, interaction, and default props
- Add Storybook stories for Default, NoSelection, SingleCoursePlan, and LongLabel scenarios
- Add CSS styling with responsive layout (3-column info row on desktop, stacked on mobile)

## Test plan

- [ ] Run `npx jest CoursePlanSelector --no-coverage` — all tests pass
- [ ] Run Storybook and verify all 4 stories render correctly
- [ ] Verify the dropdown shows all formations and the info section updates on selection
- [ ] Verify the info section is empty when no formation is selected
- [ ] Verify responsive layout on small screens (≤ 600px)